### PR TITLE
Include "context" and "extra" in basic info attachment

### DIFF
--- a/src/Slack/Attachment/BasicInfoAttachment.php
+++ b/src/Slack/Attachment/BasicInfoAttachment.php
@@ -46,6 +46,14 @@ class BasicInfoAttachment extends Attachment
 
         $this->addField(new Field('When', $this->record['datetime']->format('d/m/Y H:m:i'), true));
 
+        if (!empty($this->record['context'])) {
+            $this->addField(new Field('Context', json_encode($this->record['context'])));
+        }
+
+        if (!empty($this->record['extra'])) {
+            $this->addField(new Field('Extra', json_encode($this->record['extra'])));
+        }
+
         if ($this->error !== null) {
             $this->addField(new Field('Line', $this->error->getLine(), true));
             $this->addField(new Field('File', $this->error->getFile()));

--- a/tests/Unit/Slack/Attachment/BasicInfoAttachmentTest.php
+++ b/tests/Unit/Slack/Attachment/BasicInfoAttachmentTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pageon\SlackChannelMonolog\Tests\Unit\Slack\Attachment;
+
+use Monolog\Logger;
+use Pageon\SlackWebhookMonolog\Slack\Attachment\BasicInfoAttachment;
+use PHPUnit_Framework_TestCase;
+
+class BasicInfoAttachmentTest extends PHPUnit_Framework_TestCase
+{
+    public function testIncludesContextIfRecordHasIt()
+    {
+        $record = [
+            'message' => 'foo',
+            'level' => Logger::ALERT,
+            'level_name' => 'ALERT',
+            'datetime' => new \DateTime(),
+            'context' => ['foo' => 'bar'],
+        ];
+
+        $attachment = new BasicInfoAttachment($record);
+        $data = $attachment->get();
+
+        $this->assertArrayHasKey(2, $data['fields']);
+        $context = $data['fields'][2]->jsonSerialize();
+        $this->assertSame('Context', $context['title']);
+        $this->assertSame(json_encode(['foo' => 'bar']), $context['value']);
+    }
+
+    public function testIncludesExtraIfRecordHasIt()
+    {
+        $record = [
+            'message' => 'foo',
+            'level' => Logger::ALERT,
+            'level_name' => 'ALERT',
+            'datetime' => new \DateTime(),
+            'extra' => ['foo' => 'bar'],
+        ];
+
+        $attachment = new BasicInfoAttachment($record);
+        $data = $attachment->get();
+
+        $this->assertArrayHasKey(2, $data['fields']);
+        $context = $data['fields'][2]->jsonSerialize();
+        $this->assertSame('Extra', $context['title']);
+        $this->assertSame(json_encode(['foo' => 'bar']), $context['value']);
+    }
+}


### PR DESCRIPTION
Monolog can add additional information to a record under the keys `context` and `extra`, which would be useful in a Slack alert. For example, the `UidProcessor` will give each logger's messages a unique ID to make it easy to find them in a more detailed log file after being alerted, which appears in `extra`.

This PR will include this data in the attachment if it's present in the record.

A "better" solution would likely be making some kind of decorator available for the payload before it is fired off, but I'm not sure what the best way to do that would be. Maybe an optional config value in the `SlackConfigInterface` to indicate what class to use for formatting of the attachment? (and have the current `BasicInfoAttachment` class be the default). This would allow someone to create their own attachment class for the basic info and display whatever they need however they need it formatted.

Anyway, what is in this PR covers the basic use case that I think most people would have.
