### PR TITLE
Fix date format in "When" field

### DIFF
--- a/src/Slack/Attachment/BasicInfoAttachment.php
+++ b/src/Slack/Attachment/BasicInfoAttachment.php
@@ -44,7 +44,7 @@ class BasicInfoAttachment extends Attachment
         $this->setText(sprintf('*Error:* %s', $this->record['level_name']));
         $this->addField(new Field('What', $message));
 
-        $this->addField(new Field('When', $this->record['datetime']->format('d/m/Y H:m:i'), true));
+        $this->addField(new Field('When', $this->record['datetime']->format('d/m/Y H:i:s'), true));
 
         $this->addRecordDataAsJsonEncodedField('context', 'Context');
         $this->addRecordDataAsJsonEncodedField('extra', 'Extra');

--- a/tests/Unit/Slack/Attachment/BasicInfoAttachmentTest.php
+++ b/tests/Unit/Slack/Attachment/BasicInfoAttachmentTest.php
@@ -45,4 +45,25 @@ class BasicInfoAttachmentTest extends PHPUnit_Framework_TestCase
         $this->assertSame('Extra', $context['title']);
         $this->assertSame(json_encode(['foo' => 'bar']), $context['value']);
     }
+
+    public function testIncludesDateStamp()
+    {
+        $date = new \DateTime();
+        $record = [
+            'message' => 'foo',
+            'level' => Logger::ALERT,
+            'level_name' => 'ALERT',
+            'datetime' => $date,
+            'extra' => ['foo' => 'bar'],
+        ];
+
+        $attachment = new BasicInfoAttachment($record);
+        $data = $attachment->get();
+
+        $this->assertArrayHasKey(1, $data['fields']);
+        $when = $data['fields'][1]->jsonSerialize();
+
+        $this->assertSame('When', $when['title']);
+        $this->assertSame($date->format('d/m/Y H:i:s'), $when['value']);
+    }
 }


### PR DESCRIPTION
`d/m/Y H:m:i` should be `d/m/Y H:i:s`.

`m` is months and `i` is minutes, so the time format is currently `<hours>:<month>:<minutes>`. We want `<hours>:<minutes>:<seconds>`, which is `H:i:s`. I included a simple regression test.

Side note: I would love for this to simply use `c` as the time format, which corresponds to the ISO 8601 standard format (e.g. `2004-02-12T15:19:21+00:00`), but I realize that's more of a "change" than a bug fix. If you'd be willing to accept that change, I can modify this PR accordingly.
